### PR TITLE
Add Docker support

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+FROM openjdk:8-jre-alpine
+
+RUN apk --no-cache add bash
+
+ENV CEREBRO_VERSION 0.7.3
+ADD https://github.com/lmenezes/cerebro/releases/download/v${CEREBRO_VERSION}/cerebro-${CEREBRO_VERSION}.tgz /opt/
+RUN tar zxvf /opt/cerebro-${CEREBRO_VERSION}.tgz -C /opt && mv /opt/cerebro-${CEREBRO_VERSION} /opt/cerebro
+RUN mkdir /opt/cerebro/logs
+
+# remove logback file appender
+RUN sed -i '/<appender-ref ref="FILE"\/>/d' /opt/cerebro/conf/logback.xml
+
+WORKDIR /opt/cerebro
+EXPOSE 9000
+ENTRYPOINT ["./bin/cerebro"]


### PR DESCRIPTION
Back port Docker support from v0.8.1. This is necessary as the Dockerfile was added later and there were no existing images available for v0.7.3.
